### PR TITLE
Fix msgsAck broken by previous PR (#16)

### DIFF
--- a/lib/src/auth_key.dart
+++ b/lib/src/auth_key.dart
@@ -4,11 +4,10 @@ part of '../tg.dart';
 class AuthorizationKey {
   /// Constructor.
   AuthorizationKey(this.id, this.key, this.salt)
-      : _msgsToAck = {},
-        assert(id != 0, 'Id must not be zero.'),
+      : assert(id != 0, 'Id must not be zero.'),
         assert(key.length == 256, 'Key must be 256 bytes.');
 
-  AuthorizationKey._(this.id, this.key, this.salt, this._msgsToAck)
+  AuthorizationKey._(this.id, this.key, this.salt)
       : assert(id != 0, 'Id must not be zero.'),
         assert(key.length == 256, 'Key must be 256 bytes.');
 
@@ -22,8 +21,6 @@ class AuthorizationKey {
 
     return AuthorizationKey(id, key, salt);
   }
-
-  final Set<int> _msgsToAck;
 
   ///  Auth Key Id (int64).
   final int id;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -19,6 +19,7 @@ class Client extends t.Client {
       socket.receiver,
       obfuscation,
       authorizationKey,
+      msgsToAck,
     );
 
     _transformer.stream.listen((v) {
@@ -44,7 +45,6 @@ class Client extends t.Client {
       uot.stream,
       obfuscation,
       idGenerator,
-      msgsToAck,
     );
     final ak = await dh.exchange();
 
@@ -56,6 +56,7 @@ class Client extends t.Client {
   final Obfuscation obfuscation;
   final SocketAbstraction socket;
   final MessageIdGenerator idGenerator;
+  final Set<int> msgsToAck = {};
 
   late final _EncryptedTransformer _transformer;
 
@@ -78,6 +79,9 @@ class Client extends t.Client {
       }
       return;
     } else if (msg is Msg) {
+      if ((msg.seqno & 1) != 0) {
+        msgsToAck.add(msg.msgId);
+      }
       _handleIncomingMessage(msg.body);
       return;
     } else if (msg is BadMsgNotification) {
@@ -129,7 +133,7 @@ class Client extends t.Client {
 
       if (task != null) {
         if (task.sentAcks.isNotEmpty) {
-          authorizationKey._msgsToAck.addAll(task.sentAcks);
+          msgsToAck.addAll(task.sentAcks);
         }
         _invoke(task.method, task.completer);
       }
@@ -146,7 +150,6 @@ class Client extends t.Client {
     Completer<t.Result> completer,
   ) async {
     final preferEncryption = authorizationKey.id != 0;
-    final msgsToAck = authorizationKey._msgsToAck;
 
     final m = idGenerator._next(preferEncryption);
     List<int> currentAcks = [];

--- a/lib/src/decoders.dart
+++ b/lib/src/decoders.dart
@@ -5,6 +5,7 @@ class _EncryptedTransformer {
     this._receiver,
     this._obfuscation,
     this._authorizationKey,
+    this._msgsToAck,
   ) {
     _receiver.listen(_readFrame);
   }
@@ -17,6 +18,7 @@ class _EncryptedTransformer {
   final Stream<List<int>> _receiver;
   final Obfuscation _obfuscation;
   final AuthorizationKey _authorizationKey;
+  final Set<int> _msgsToAck;
 
   final List<int> _read = [];
   int? _length;
@@ -48,7 +50,7 @@ class _EncryptedTransformer {
       final seqno = frame.seqno;
 
       if (seqno != null && (seqno & 1) != 0) {
-        _authorizationKey._msgsToAck.add(frame.messageId);
+        _msgsToAck.add(frame.messageId);
       }
 
       _streamController.add(frame.message);

--- a/lib/src/diffie_hellman.dart
+++ b/lib/src/diffie_hellman.dart
@@ -6,7 +6,6 @@ class _DiffieHellman {
     this.receiver,
     this.obfuscation,
     this.idGenerator,
-    this._msgsToAck,
   ) {
     receiver.listen(_onMessage);
   }
@@ -14,7 +13,6 @@ class _DiffieHellman {
   final Obfuscation? obfuscation;
   final Stream<TlObject> receiver;
   final SocketAbstraction socket;
-  final Set<int> _msgsToAck;
 
   void _onMessage(TlObject msg) {
     if (msg is ResPQ) {
@@ -333,7 +331,6 @@ class _DiffieHellman {
       authKeyID,
       authKey,
       saltLeft ^ saltRight,
-      _msgsToAck,
     );
 
     return ak;


### PR DESCRIPTION
When the server sent a BadServerSalt, the Client generated a new AuthorizationKey instance, implicitly dropping the previous _msgsToAck queue. This caused the transformer to push ACKs to an orphaned _msgsToAck list